### PR TITLE
chore: 添加编辑器支持提示

### DIFF
--- a/packages/editor/webpack/launchEditor.js
+++ b/packages/editor/webpack/launchEditor.js
@@ -171,10 +171,35 @@ function getArgumentsForLineNumber(editor, fileName, lineNumber, colNumber, work
   return [fileName]
 }
 
+function aliasTransform(mometaEditor) {
+  let commonEditors;
+  if (process.platform === 'darwin') {
+    commonEditors = Object.values(COMMON_EDITORS_OSX)
+  } else if (process.platform === 'win32') {
+    commonEditors = Object.values(COMMON_EDITORS_WIN)
+  } else if (process.platform === 'linux') {
+    commonEditors = Object.values(COMMON_EDITORS_LINUX)
+  }
+  const editors = Object.values(commonEditors)
+  for (let i = 0; i < editors.length; i++) {
+    const editor = editors[i]
+    if (editor === mometaEditor) return editor
+  }
+  console.log()
+  console.log(chalk.red('Don\'t find editor: ' + mometaEditor))
+  console.log()
+  console.log(
+    chalk.green('Editor should be one of these: ') + editors.join(" | ")
+  )
+  console.log()
+  throw new Error('Could not open ' + mometaEditor)
+}
+
 function guessEditor() {
   // Explicit config always wins
   if (process.env.MOMETA_EDITOR) {
-    return shellQuote.parse(process.env.MOMETA_EDITOR)
+    const editor = aliasTransform(process.env.MOMETA_EDITOR)
+    return shellQuote.parse(editor)
   }
 
   // We can find out which editor is currently running by:


### PR DESCRIPTION
在 mac pro 中，将 MOMETA_EDITOR 配置设置为 “vscode” 时 会提示 "The editor process exited with an error: spawn vscode ENOENT."，因为 vscode 的执行名称应该为 “code”，而很多用户并不清楚应用的真实名称，特别是诸如 ‘/Applications/GoLand.app/Contents/MacOS/goland’ 之类的。所以这个 pr 会在预期 MOMETA_EDITOR 不匹配时提供正确的参考。

issue22: https://github.com/imcuttle/mometa/issues/22